### PR TITLE
blurry background + placeholder

### DIFF
--- a/Pod/Classes/BMInputBox.swift
+++ b/Pod/Classes/BMInputBox.swift
@@ -37,7 +37,12 @@ public class BMInputBox: UIView {
   
   /// The current style of the box
   @objc public var style: BMInputBoxStyle = .plainTextInput
-  
+
+  /// Placeholder text for the field if needed
+  public var placeholder: String?
+
+  /// Should background below the box be blurred
+  public var isBackgroundBlurred: Bool = false
   
   /**
    Customisation of the NumberInput type
@@ -85,7 +90,12 @@ public class BMInputBox: UIView {
   
   /// Visual effects view holding the content
   private var visualEffectView: UIVisualEffectView?
-  
+
+  /// Visual effect style for the background
+  public var backgroundBlurEffectStyle: UIBlurEffectStyle?
+
+  /// Visual effects view on the background
+  private var backgroundVisualEffectView: UIVisualEffectView?
   
   /**
    Class method creating an instace of the input box with a specific style. See BMInputBoxStyle for available styles. Every style comes with different kind and number of input types.
@@ -110,15 +120,27 @@ public class BMInputBox: UIView {
    Shows the input box
    */
   public func show () {
-    
+
+    self.backgroundVisualEffectView?.alpha = 0
     self.alpha = 0
     self.setupView()
-    
-    UIView.animate(withDuration: 0.3, animations: { () -> Void in
-      self.alpha = 1
-    })
-    
+
     let window = UIApplication.shared.windows.first as UIWindow!
+
+    if isBackgroundBlurred {
+        backgroundVisualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: self.backgroundBlurEffectStyle ?? .dark))
+        backgroundVisualEffectView?.frame = window?.frame ?? .zero
+    }
+
+    UIView.animate(withDuration: 0.3, animations: { () -> Void in
+        self.backgroundVisualEffectView?.alpha = 1
+        self.alpha = 1
+    })
+
+    if let backgroundVisualEffectView = backgroundVisualEffectView {
+        window?.addSubview(backgroundVisualEffectView)
+    }
+
     window?.addSubview(self)
     window?.bringSubview(toFront: self)
     
@@ -136,8 +158,10 @@ public class BMInputBox: UIView {
    */
   public func hide () {
     UIView.animate(withDuration: 0.3, animations: { () -> Void in
+      self.backgroundVisualEffectView?.alpha = 0
       self.alpha = 0
     }) { (completed) -> Void in
+      self.backgroundVisualEffectView?.removeFromSuperview()
       self.removeFromSuperview()
       
       // Rotation support
@@ -201,7 +225,8 @@ public class BMInputBox: UIView {
       self.textInput = UITextField(frame: CGRect(x: padding, y: messageLabel.frame.origin.y + messageLabel.frame.size.height + padding / 1.5, width: width, height: 35))
       self.textInput?.textAlignment = .center
       self.textInput?.textColor = (isDark) ? UIColor.white : UIColor.black
-      
+      self.textInput?.text = placeholder
+
       // Allow customisation
       if self.customiseInputElement != nil {
         self.textInput = self.customiseInputElement(self.textInput!)

--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ UIBlurEffectStyle: .extraLight, .light, .dark
 inputBox.blurEffectStyle = .light
 ```
 
+#### Blurry Background
+
+UIBlurEffectStyle: .extraLight, .light, .dark
+
+```Swift
+inputBox.isBackgroundBlurred = true
+inputBox.backgroundBlurEffectStyle = .dark
+```
+
 #### Custom Texts And I18n
 
 You can set a custom text for all the components in the view.
@@ -70,6 +79,7 @@ inputBox.message = NSLocalizedString("This is the message in the view, can be as
 inputBox.submitButtonText = NSLocalizedString("OK", comment: "")
 inputBox.cancelButtonText = NSLocalizedString("Cancel", comment: "")
 inputBox.validationLabelText = NSLocalizedString("Text must be 6 characters long.", comment: "")
+inputBox.placeholder = NSLocalizedString("Example title", comment: "")
 ```
 
 #### Mandatory Decimals


### PR DESCRIPTION
Added property placeholder for setting up the text for the field.
Added property isBackgroundBlurred, if true - it'll show the blur background below the alert.

P.S. don't you think that property name "placeholder" can be accidentally mixed up with the original property of UITextField "placeholder" which has another sense?